### PR TITLE
NOJIRA Specify compilation targets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,19 @@
     <groupId>currencycloud</groupId>
     <artifactId>pair-java</artifactId>
     <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <dependencies>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.0</version>
-        <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
-
+    
 </project>


### PR DESCRIPTION
Without properties, the following error is yielded when running tests
in IntelliJ:

```
java: error: release version 5 not supported
```

This directs maven & junit jupiter to compile to java 8.